### PR TITLE
Добавил очередь проигрывания

### DIFF
--- a/LiboLibo/Features/Feed/FeedView.swift
+++ b/LiboLibo/Features/Feed/FeedView.swift
@@ -39,7 +39,8 @@ struct FeedView: View {
         } else {
             List(repository.allEpisodes) { episode in
                 EpisodeListItem(episode: episode) {
-                    player.play(episode)
+                    let context = repository.allEpisodes.sorted { $0.pubDate < $1.pubDate }
+                    player.play(episode, context: context)
                 } onShowDetail: {
                     path.append(episode)
                 }

--- a/LiboLibo/Features/Player/PlayerView.swift
+++ b/LiboLibo/Features/Player/PlayerView.swift
@@ -8,6 +8,7 @@ struct PlayerView: View {
     @Environment(PodcastColorService.self) private var colors
     @Environment(\.dismiss) private var dismiss
     @State private var showsNotes = false
+    @State private var showQueue = false
 
     var body: some View {
         if let episode = player.currentEpisode {
@@ -40,6 +41,8 @@ struct PlayerView: View {
 
                 UtilityRow(episode: episode, tint: tint) {
                     showsNotes = true
+                } onShowQueue: {
+                    showQueue = true
                 }
 
                 Spacer(minLength: 24)
@@ -53,6 +56,9 @@ struct PlayerView: View {
             }
             .sheet(isPresented: $showsNotes) {
                 EpisodeNotesSheet(episode: episode)
+            }
+            .sheet(isPresented: $showQueue) {
+                QueueSheetView()
             }
         }
     }
@@ -189,6 +195,7 @@ private struct UtilityRow: View {
     let episode: Episode
     let tint: TintColor?
     let onShowNotes: () -> Void
+    let onShowQueue: () -> Void
 
     @Environment(PlayerService.self) private var player
 
@@ -220,6 +227,16 @@ private struct UtilityRow: View {
             }
             .buttonStyle(.plain)
             .accessibilityLabel("Описание выпуска")
+
+            Button(action: onShowQueue) {
+                Image(systemName: "list.bullet")
+                    .font(.title3)
+                    .foregroundStyle(.primary)
+                    .frame(width: 44, height: 44)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Очередь")
         }
     }
 }
@@ -290,11 +307,13 @@ private struct PillButton: View {
     var body: some View {
         let highlightedBg = tint?.accent ?? Color.primary.opacity(0.7)
         Button(action: action) {
-            HStack(spacing: 6) {
+            HStack(spacing: text.isEmpty ? 0 : 6) {
                 Image(systemName: icon)
-                Text(text)
-                    .font(.subheadline)
-                    .fontWeight(.medium)
+                if !text.isEmpty {
+                    Text(text)
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                }
             }
             .padding(.horizontal, 14)
             .padding(.vertical, 10)

--- a/LiboLibo/Features/Player/QueueSheetView.swift
+++ b/LiboLibo/Features/Player/QueueSheetView.swift
@@ -1,0 +1,137 @@
+import SwiftUI
+
+struct QueueSheetView: View {
+    @Environment(PlayerService.self) private var player
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ScrollViewReader { proxy in
+                List {
+                    previousSection
+                    nowPlayingSection
+                    upNextSection
+                }
+                .listStyle(.insetGrouped)
+                .onAppear {
+                    proxy.scrollTo("nowPlaying", anchor: .top)
+                }
+            }
+            .navigationTitle("Очередь")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Готово") { dismiss() }
+                }
+            }
+        }
+    }
+
+    // MARK: - Sections
+
+    @ViewBuilder
+    private var previousSection: some View {
+        let items = episodesBefore
+        if !items.isEmpty {
+            Section("Предыдущие") {
+                ForEach(items) { episode in
+                    Button {
+                        player.play(episode)
+                        dismiss()
+                    } label: {
+                        QueueRow(episode: episode)
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var nowPlayingSection: some View {
+        if let current = player.currentEpisode {
+            Section("Сейчас играет") {
+                HStack(spacing: 12) {
+                    QueueRow(episode: current)
+                    Spacer(minLength: 0)
+                    if player.isPlaying {
+                        Image(systemName: "waveform")
+                            .symbolEffect(.pulse)
+                            .foregroundStyle(.tint)
+                            .font(.subheadline)
+                    } else {
+                        Image(systemName: "pause.fill")
+                            .foregroundStyle(.secondary)
+                            .font(.subheadline)
+                    }
+                }
+                .id("nowPlaying")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var upNextSection: some View {
+        let items = episodesAfter
+        if !items.isEmpty {
+            Section("Далее") {
+                ForEach(items) { episode in
+                    Button {
+                        player.play(episode)
+                        dismiss()
+                    } label: {
+                        QueueRow(episode: episode)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private var episodesBefore: [Episode] {
+        guard let current = player.currentEpisode,
+              let idx = player.feedContext.firstIndex(where: { $0.id == current.id }),
+              idx > 0 else { return [] }
+        return Array(player.feedContext.prefix(idx))
+    }
+
+    private var episodesAfter: [Episode] {
+        guard let current = player.currentEpisode,
+              let idx = player.feedContext.firstIndex(where: { $0.id == current.id }),
+              idx + 1 < player.feedContext.count else { return [] }
+        return Array(player.feedContext.suffix(from: idx + 1))
+    }
+}
+
+private struct QueueRow: View {
+    let episode: Episode
+
+    var body: some View {
+        HStack(spacing: 12) {
+            AsyncImage(url: episode.podcastArtworkUrl) { phase in
+                switch phase {
+                case .success(let image):
+                    image.resizable().aspectRatio(contentMode: .fill)
+                default:
+                    Color.secondary.opacity(0.15)
+                }
+            }
+            .frame(width: 44, height: 44)
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(episode.podcastName)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                Text(episode.title)
+                    .font(.subheadline)
+                    .lineLimit(2)
+            }
+        }
+        .padding(.vertical, 2)
+    }
+}

--- a/LiboLibo/Features/Podcasts/PodcastDetailView.swift
+++ b/LiboLibo/Features/Podcasts/PodcastDetailView.swift
@@ -80,7 +80,10 @@ struct PodcastDetailView: View {
                     ForEach(episodes) { episode in
                         EpisodeListItem(
                             episode: episode,
-                            onPlay: { player.play(episode) },
+                            onPlay: {
+                                let context = episodes.sorted { $0.pubDate < $1.pubDate }
+                                player.play(episode, context: context)
+                            },
                             onShowDetail: { path.append(episode) }
                         )
                         .listRowBackground(Color.clear)

--- a/LiboLibo/Features/Profile/ProfileView.swift
+++ b/LiboLibo/Features/Profile/ProfileView.swift
@@ -112,7 +112,12 @@ struct ProfileView: View {
             ForEach(recentFromSubscriptions) { episode in
                 EpisodeListItem(
                     episode: episode,
-                    onPlay: { player.play(episode) },
+                    onPlay: {
+                        let context = repository.allEpisodes
+                            .filter { $0.podcastId == episode.podcastId }
+                            .sorted { $0.pubDate < $1.pubDate }
+                        player.play(episode, context: context)
+                    },
                     onShowDetail: { path.append(episode) }
                 )
             }

--- a/LiboLibo/Services/PlayerService.swift
+++ b/LiboLibo/Services/PlayerService.swift
@@ -13,6 +13,10 @@ final class PlayerService {
     private(set) var currentTime: TimeInterval = 0
     private(set) var duration: TimeInterval = 0
 
+    /// Все эпизоды текущего подкаста, отсортированные от старых к новым.
+    /// Используется для навигации по выпускам (вперёд/назад) и отображения очереди.
+    private(set) var feedContext: [Episode] = []
+
     var rate: Float = 1.0 {
         didSet {
             if isPlaying {
@@ -72,11 +76,17 @@ final class PlayerService {
         configureAudioSession()
         setupTimeObserver()
         setupRemoteCommands()
+        setupEndOfItemObserver()
     }
 
     // MARK: - Public API
 
-    func play(_ episode: Episode) {
+    /// Запускает эпизод. Если передан context — обновляет ленту эпизодов подкаста.
+    /// context должен быть отсортирован от старых к новым.
+    func play(_ episode: Episode, context: [Episode] = []) {
+        if !context.isEmpty {
+            feedContext = context
+        }
         if currentEpisode?.id == episode.id {
             resume()
             return
@@ -157,6 +167,29 @@ final class PlayerService {
         updateNowPlayingInfo()
     }
 
+    private func setupEndOfItemObserver() {
+        NotificationCenter.default.addObserver(
+            forName: AVPlayerItem.didPlayToEndTimeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                self.playNextInContext()
+            }
+        }
+    }
+
+    private func playNextInContext() {
+        guard let current = currentEpisode,
+              let idx = feedContext.firstIndex(where: { $0.id == current.id }),
+              idx + 1 < feedContext.count else {
+            isPlaying = false
+            return
+        }
+        play(feedContext[idx + 1])
+    }
+
     private func configureAudioSession() {
         let session = AVAudioSession.sharedInstance()
         try? session.setCategory(.playback, mode: .default, options: [])
@@ -203,6 +236,10 @@ final class PlayerService {
         cc.skipBackwardCommand.preferredIntervals = [10]
         cc.skipBackwardCommand.addTarget { [weak self] _ in
             Task { @MainActor in self?.skip(by: -10) }
+            return .success
+        }
+        cc.nextTrackCommand.addTarget { [weak self] _ in
+            Task { @MainActor in self?.playNextInContext() }
             return .success
         }
         cc.changePlaybackPositionCommand.addTarget { [weak self] event in


### PR DESCRIPTION
Привет! Решил поправить собственную боль с Apple Podcasts - отсутствие старых эпизодов в очереди. Если хочешь вернуться к прошлому эпизоду у эпла это невозможно без перехода в ленту подкаста и ручного поиска выпуска. Скрин прилагаю.
Очередь в фиде учитывает фид и отдает все подкасты, очередь в подкасте соответственно только его выпуски.
P.S. уже есть конфликты, постараюсь зарезолвить и докинуть коммит в этот же пр
<img width="458" height="873" alt="Screenshot 2026-04-25 at 14 18 32" src="https://github.com/user-attachments/assets/1e1b3398-aa73-4aee-8396-6777fd6064e7" />
