### PR TITLE
Подключить Adapty SDK 3.15.7 в iOS-приложение

### DIFF
--- a/LiboLibo.xcodeproj/project.pbxproj
+++ b/LiboLibo.xcodeproj/project.pbxproj
@@ -6,6 +6,11 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		5608F0C5475557DE848B4CCD /* Adapty in Frameworks */ = {isa = PBXBuildFile; productRef = EFDE8DE47A086D4A0EB06CBF /* Adapty */; };
+		61AED75728C459CC19815B4E /* AdaptyUI in Frameworks */ = {isa = PBXBuildFile; productRef = F210B71E9EA1043C2C60B901 /* AdaptyUI */; };
+/* End PBXBuildFile section */
+
 /* Begin PBXFileReference section */
 		BD3C7DBDF1D3E2ED6B0D9ED6 /* LiboLibo.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = LiboLibo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -13,10 +18,24 @@
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		C49B7815EC13F05F2FEBA9E5 /* LiboLibo */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
 			path = LiboLibo;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		5ED32FDC06237C4DE15E3ACE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5608F0C5475557DE848B4CCD /* Adapty in Frameworks */,
+				61AED75728C459CC19815B4E /* AdaptyUI in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
 		487DB0F67E11E74CF9E2D579 /* Products */ = {
@@ -44,6 +63,7 @@
 			buildPhases = (
 				AD8AB8B62246D2B282A94CDC /* Sources */,
 				29B33F039134F04488E751CE /* Resources */,
+				5ED32FDC06237C4DE15E3ACE /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -54,6 +74,8 @@
 			);
 			name = LiboLibo;
 			packageProductDependencies = (
+				EFDE8DE47A086D4A0EB06CBF /* Adapty */,
+				F210B71E9EA1043C2C60B901 /* AdaptyUI */,
 			);
 			productName = LiboLibo;
 			productReference = BD3C7DBDF1D3E2ED6B0D9ED6 /* LiboLibo.app */;
@@ -83,6 +105,9 @@
 			);
 			mainGroup = FC5DF9317D0D811CC74D8A39;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				36AB1BA02C8FEFDB8E0E3300 /* XCRemoteSwiftPackageReference "AdaptySDK-iOS" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 487DB0F67E11E74CF9E2D579 /* Products */;
 			projectDirPath = "";
@@ -117,11 +142,13 @@
 		6E04F613EEC1CF3DA989E6DF /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ADAPTY_PUBLIC_SDK_KEY = "";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGNING_ALLOWED = NO;
 				CODE_SIGN_STYLE = Automatic;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_ADAPTY_PUBLIC_SDK_KEY = "$(ADAPTY_PUBLIC_SDK_KEY)";
 				INFOPLIST_KEY_CFBundleDisplayName = "Либо-Либо";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIBackgroundModes = audio;
@@ -262,11 +289,13 @@
 		E3F124E52D6F454A08525EE6 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ADAPTY_PUBLIC_SDK_KEY = "";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGNING_ALLOWED = NO;
 				CODE_SIGN_STYLE = Automatic;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_ADAPTY_PUBLIC_SDK_KEY = "$(ADAPTY_PUBLIC_SDK_KEY)";
 				INFOPLIST_KEY_CFBundleDisplayName = "Либо-Либо";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIBackgroundModes = audio;
@@ -305,6 +334,30 @@
 			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		36AB1BA02C8FEFDB8E0E3300 /* XCRemoteSwiftPackageReference "AdaptySDK-iOS" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/adaptyteam/AdaptySDK-iOS";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 3.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		EFDE8DE47A086D4A0EB06CBF /* Adapty */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 36AB1BA02C8FEFDB8E0E3300 /* XCRemoteSwiftPackageReference "AdaptySDK-iOS" */;
+			productName = Adapty;
+		};
+		F210B71E9EA1043C2C60B901 /* AdaptyUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 36AB1BA02C8FEFDB8E0E3300 /* XCRemoteSwiftPackageReference "AdaptySDK-iOS" */;
+			productName = AdaptyUI;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = E288CBB3EC09EAE3933787C3 /* Project object */;
 }

--- a/LiboLibo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/LiboLibo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "1bd6ac241862975235a7643b803812ad86f9e0ae036d6ae8c37f482a802c47ea",
+  "pins" : [
+    {
+      "identity" : "adaptysdk-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/adaptyteam/AdaptySDK-iOS",
+      "state" : {
+        "revision" : "b751c42bccb04c97bcb6bab29a06571e4098a9f1",
+        "version" : "3.15.7"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/LiboLibo/Features/Subscription/AdaptyPaywallView.swift
+++ b/LiboLibo/Features/Subscription/AdaptyPaywallView.swift
@@ -1,33 +1,47 @@
 import SwiftUI
+import Adapty
+import AdaptyUI
 
-/// SwiftUI-обёртка над AdaptyUI paywall'ом.
-///
-/// **Текущее состояние:** SPM-зависимости Adapty / AdaptyUI ещё не
-/// подключены, поэтому здесь — placeholder-View с описанием подписки и
-/// кнопкой «Закрыть». UX-flow можно тестировать уже сейчас: тап на премиум →
-/// `EpisodeDetailView` → кнопка → sheet с этим View.
-///
-/// **TODO (после SPM Adapty + AdaptyUI):** заменить тело на
-/// `UIViewControllerRepresentable` над `AdaptyPaywallController`:
-/// ```swift
-/// let paywall = try await Adapty.getPaywall(placementId: placementId, locale: "ru")
-/// let config = try await AdaptyUI.getViewConfiguration(forPaywall: paywall)
-/// let controller = AdaptyPaywallController(
-///     paywall: paywall,
-///     viewConfiguration: config,
-///     delegate: ...
-/// )
-/// ```
-/// Колбэки делегата:
-/// - `.didFinishPurchase` → `onPurchase()` (далее AdaptyService.refreshEntitlement)
-/// - `.didFinishRestore` → если premium активен — `onPurchase()`, иначе `onClose()`
-/// - `.didCancel` → `onClose()`
+/// SwiftUI-обёртка над AdaptyUI paywall'ом. Загружает paywall и его
+/// view-конфигурацию по `placementId` из Adapty Dashboard, рендерит
+/// `AdaptyPaywallController`. Если placement не сконфигурирован в дашборде,
+/// нет сети, или SDK не активирован — показывает fallback-плашку.
 struct AdaptyPaywallView: View {
     let placementId: String
     var onPurchase: () -> Void = {}
     var onClose: () -> Void = {}
 
+    @State private var configuration: AdaptyUI.PaywallConfiguration?
+    @State private var loadError: Error?
+
     var body: some View {
+        ZStack {
+            if let configuration {
+                PaywallControllerWrapper(
+                    configuration: configuration,
+                    onPurchase: onPurchase,
+                    onClose: onClose
+                )
+                .ignoresSafeArea()
+            } else if loadError != nil {
+                fallback
+            } else {
+                ProgressView()
+                    .controlSize(.large)
+            }
+        }
+        .task(id: placementId) {
+            do {
+                let paywall = try await Adapty.getPaywall(placementId: placementId, locale: "ru")
+                let config = try await AdaptyUI.getPaywallConfiguration(forPaywall: paywall)
+                self.configuration = config
+            } catch {
+                self.loadError = error
+            }
+        }
+    }
+
+    private var fallback: some View {
         VStack(spacing: 20) {
             Spacer()
             Image(systemName: "lock.shield.fill")
@@ -35,13 +49,10 @@ struct AdaptyPaywallView: View {
                 .foregroundStyle(.liboRed)
             Text("Премиум-подписка")
                 .font(.title2.bold())
-            Text("Бонусные и эксклюзивные выпуски «Либо-Либо».")
+            Text("Сейчас покупка недоступна.\nПопробуй позже.")
                 .multilineTextAlignment(.center)
                 .foregroundStyle(.secondary)
                 .padding(.horizontal, 32)
-            Text("Подключение Adapty SDK — следующий шаг.")
-                .font(.footnote)
-                .foregroundStyle(.tertiary)
             Spacer()
             Button {
                 onClose()
@@ -55,5 +66,106 @@ struct AdaptyPaywallView: View {
             .padding(.bottom, 16)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+private struct PaywallControllerWrapper: UIViewControllerRepresentable {
+    let configuration: AdaptyUI.PaywallConfiguration
+    let onPurchase: () -> Void
+    let onClose: () -> Void
+
+    func makeUIViewController(context: Context) -> UIViewController {
+        do {
+            return try AdaptyUI.paywallController(
+                with: configuration,
+                delegate: context.coordinator
+            )
+        } catch {
+            return UIViewController()
+        }
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onPurchase: onPurchase, onClose: onClose)
+    }
+
+    final class Coordinator: NSObject, AdaptyPaywallControllerDelegate {
+        private let onPurchase: () -> Void
+        private let onClose: () -> Void
+
+        init(onPurchase: @escaping () -> Void, onClose: @escaping () -> Void) {
+            self.onPurchase = onPurchase
+            self.onClose = onClose
+        }
+
+        // MARK: - Close action
+
+        func paywallController(
+            _ controller: AdaptyPaywallController,
+            didPerform action: AdaptyUI.Action
+        ) {
+            switch action {
+            case .close:
+                onClose()
+            case .openURL, .custom:
+                break
+            @unknown default:
+                break
+            }
+        }
+
+        // MARK: - Purchase
+
+        func paywallController(
+            _ controller: AdaptyPaywallController,
+            didFinishPurchase product: AdaptyPaywallProduct,
+            purchaseResult: AdaptyPurchaseResult
+        ) {
+            switch purchaseResult {
+            case .success:
+                onPurchase()
+            case .userCancelled, .pending:
+                break
+            @unknown default:
+                break
+            }
+        }
+
+        func paywallController(
+            _ controller: AdaptyPaywallController,
+            didFailPurchase product: AdaptyPaywallProduct,
+            error: AdaptyError
+        ) {
+            // оставляем юзера на paywall'е, он сам решит — закрыть или попробовать ещё.
+        }
+
+        // MARK: - Restore
+
+        func paywallController(
+            _ controller: AdaptyPaywallController,
+            didFinishRestoreWith profile: AdaptyProfile
+        ) {
+            // Если в профиле уже есть активный access level — считаем восстановлением.
+            // refreshEntitlement в onPurchase всё равно перепроверит на сервере.
+            onPurchase()
+        }
+
+        func paywallController(
+            _ controller: AdaptyPaywallController,
+            didFailRestoreWith error: AdaptyError
+        ) {
+            // молча — UI остаётся на paywall'е.
+        }
+
+        // MARK: - Required no-op
+
+        func paywallController(
+            _ controller: AdaptyPaywallController,
+            didFailRenderingWith error: AdaptyUIError
+        ) {
+            onClose()
+        }
     }
 }

--- a/LiboLibo/Services/AdaptyService.swift
+++ b/LiboLibo/Services/AdaptyService.swift
@@ -1,10 +1,10 @@
 import Foundation
 import Observation
+import Adapty
+import AdaptyUI
 
 /// Источник правды о премиум-подписке на стороне iOS.
 ///
-/// Архитектура и решения — `docs/specs/step-2.3-premium-adapty-ios.md`. В двух
-/// словах:
 /// - идентификатор зрителя — `adapty_profile_id` (UUID), его выдаёт Adapty SDK
 ///   и сам кладёт в Keychain;
 /// - решение «есть ли премиум» принимает бэкенд (`POST /v1/me/entitlement/refresh`),
@@ -13,14 +13,10 @@ import Observation
 /// - локальный `isPremium` влияет только на UI; бэк независимо гейтит
 ///   `audio_url`, поэтому подмена локального флага не даёт доступа к контенту.
 ///
-/// **Текущее состояние:** SPM-зависимости Adapty / AdaptyUI ещё не подключены,
-/// поэтому `activate()` и `restorePurchases()` — заглушки, `profileId`
-/// остаётся `nil` и заголовок `X-Adapty-Profile-Id` не шлётся (бэк видит
-/// анонимного зрителя, как и до этой фазы). После добавления SPM нужно
-/// заменить тела `activate()` и `restorePurchases()` (TODO-комментарии внутри),
-/// вытащить `ADAPTY_PUBLIC_SDK_KEY` из `Info.plist` и оживить
-/// `AdaptyPaywallView`. Остальная инфраструктура (refresh, кэш, welcome-логика,
-/// UI) уже работает.
+/// Ключ `ADAPTY_PUBLIC_SDK_KEY` пробрасывается в `Info.plist` через
+/// User-Defined Build Setting (см. `LiboLibo.xcodeproj`). Если ключ пустой —
+/// SDK не активируется, `profileId` остаётся `nil`, бэк видит анонимного
+/// зрителя (поведение для существующих юзеров не меняется).
 @MainActor
 @Observable
 final class AdaptyService {
@@ -28,9 +24,7 @@ final class AdaptyService {
     private(set) var isPremium: Bool = false
     private(set) var expiresAt: Date?
     private(set) var lastRefreshAt: Date?
-    /// `true`, когда Adapty SDK успешно поднялся и `profileId` известен. До
-    /// подключения SPM — всегда `false`. Используется для гейта welcome-paywall'а
-    /// и реальных триггеров (заглушку paywall'а показывать не пытаемся).
+    /// `true`, когда Adapty SDK успешно поднялся и `profileId` известен.
     private(set) var isActivated: Bool = false
 
     private let api: APIClient
@@ -44,30 +38,36 @@ final class AdaptyService {
 
     // MARK: - Lifecycle
 
-    /// Поднимает Adapty SDK, фиксирует `profileId`, делает первый
-    /// `refreshEntitlement`. Зовётся из `LiboLiboApp.onAppear` (cold start).
-    ///
-    /// **TODO (после SPM-add Adapty + AdaptyUI):**
-    /// ```swift
-    /// guard let key = Bundle.main.object(forInfoDictionaryKey: "ADAPTY_PUBLIC_SDK_KEY") as? String,
-    ///       !key.isEmpty else { return }
-    /// let config = AdaptyConfiguration.builder(withAPIKey: key).build()
-    /// try? await Adapty.activate(with: config)
-    /// if let profile = try? await Adapty.getProfile(),
-    ///    let id = UUID(uuidString: profile.profileId) {
-    ///     self.profileId = id
-    ///     self.isActivated = true
-    /// }
-    /// await refreshEntitlement()
-    /// ```
+    /// Поднимает Adapty SDK (если есть ключ), фиксирует `profileId`. Зовётся
+    /// из `LiboLiboApp.task` (cold start). После — `refreshEntitlement`
+    /// зовётся отдельно из composition root, чтобы вызывающий мог решить,
+    /// нужно ли перезагружать ленту.
     func activate() async {
-        // No-op до подключения Adapty SDK. APIClient.profileIdProvider
-        // вернёт nil, бэк продолжит видеть анонимного зрителя.
+        guard let key = Bundle.main.object(forInfoDictionaryKey: "ADAPTY_PUBLIC_SDK_KEY") as? String,
+              !key.isEmpty else {
+            return
+        }
+        do {
+            let configuration = AdaptyConfiguration
+                .builder(withAPIKey: key)
+                .build()
+            try await Adapty.activate(with: configuration)
+            try await AdaptyUI.activate()
+            let profile = try await Adapty.getProfile()
+            if let id = UUID(uuidString: profile.profileId) {
+                self.profileId = id
+                self.isActivated = true
+                defaults.set(profile.profileId, forKey: Keys.profileId)
+            }
+        } catch {
+            // SDK не поднялся — остаёмся в anon mode.
+        }
     }
 
     /// Дёргает `POST /v1/me/entitlement/refresh`, обновляет локальное состояние
-    /// и возвращает `true`, если значение `isPremium` изменилось (тогда вызывающий
-    /// должен перегрузить ленту: `audio_url` зависит от viewer'а на бэке).
+    /// и возвращает `true`, если значение `isPremium` изменилось (тогда
+    /// вызывающий должен перегрузить ленту: `audio_url` зависит от viewer'а
+    /// на бэке).
     @discardableResult
     func refreshEntitlement() async -> Bool {
         guard profileId != nil else { return false }
@@ -81,19 +81,15 @@ final class AdaptyService {
 
     /// Restore через Adapty SDK + последующий refresh. Зовётся по тапу
     /// «Восстановить покупки» в `ProfileView`.
-    ///
-    /// **TODO (после SPM):**
-    /// ```swift
-    /// do {
-    ///     _ = try await Adapty.restorePurchases()
-    ///     let changed = await refreshEntitlement()
-    ///     return isPremium ? .restored : .nothingToRestore
-    /// } catch {
-    ///     return .failed(error)
-    /// }
-    /// ```
     func restorePurchases() async -> RestoreOutcome {
-        return .nothingToRestore
+        guard isActivated else { return .nothingToRestore }
+        do {
+            _ = try await Adapty.restorePurchases()
+            await refreshEntitlement()
+            return isPremium ? .restored : .nothingToRestore
+        } catch {
+            return .failed(error)
+        }
     }
 
     /// Помечает, что welcome-paywall был показан. Дальше 7 дней не показываем.
@@ -101,10 +97,9 @@ final class AdaptyService {
         defaults.set(Date(), forKey: Keys.welcomePaywallLastShownAt)
     }
 
-    /// `true`, если на cold start стоит показать welcome-paywall:
-    /// SDK поднят, премиума нет, последний показ был ≥ 7 дней назад (или его
-    /// не было вовсе). До подключения SPM `isActivated == false`, поэтому
-    /// welcome не появляется — это ожидаемо.
+    /// `true`, если на cold start стоит показать welcome-paywall: SDK
+    /// активирован, премиума нет, последний показ был ≥ 7 дней назад (или
+    /// его не было вовсе).
     var shouldShowWelcomePaywall: Bool {
         guard isActivated, !isPremium else { return false }
         guard let last = defaults.object(forKey: Keys.welcomePaywallLastShownAt) as? Date else {
@@ -131,7 +126,7 @@ final class AdaptyService {
     }
 
     /// Применяет ответ бэка и пишет в кэш. Возвращает `true`, если `isPremium`
-    /// изменился — это сигнал перегрузить ленту.
+    /// изменился.
     private func applyEntitlement(_ dto: EntitlementDTO) -> Bool {
         let wasPremium = isPremium
         self.isPremium = dto.isPremium

--- a/docs/sessions/2026-04-25-27-adapty-sdk-wired.md
+++ b/docs/sessions/2026-04-25-27-adapty-sdk-wired.md
@@ -1,0 +1,54 @@
+# 2026-04-25-27 — Adapty SDK подключён в iOS-приложение
+
+## Контекст
+
+Сразу после сессии 26 (каркас фазы 2.3 iOS — заглушки `AdaptyService` + `AdaptyPaywallView` без SPM-зависимости). Пользователь подтвердил, что ключи Adapty есть, и попросил подключить SDK сейчас.
+
+## Что сделали
+
+1. **SPM-зависимость:** добавили `https://github.com/adaptyteam/AdaptySDK-iOS` (резолвится в `3.15.7`) с продуктами `Adapty` + `AdaptyUI`. Сделали через ruby `xcodeproj` gem ([`scripts/add_adapty_spm.rb`](../../scripts/add_adapty_spm.rb), идемпотентный) — устанавливать SPM через CLI Xcode не умеет, но `xcodeproj` правит `project.pbxproj` напрямую. Скрипт оставлен в репо для воспроизводимости.
+
+2. **Build settings:** в `LiboLibo.xcodeproj`:
+   - `ADAPTY_PUBLIC_SDK_KEY` — пустой (User-Defined). Пользователь вписывает ключ через Xcode → Project → Build Settings.
+   - `INFOPLIST_KEY_ADAPTY_PUBLIC_SDK_KEY = $(ADAPTY_PUBLIC_SDK_KEY)` — пробрасывает в сгенерированный Info.plist (проект использует `GENERATE_INFOPLIST_FILE = YES`).
+
+3. **`AdaptyService` — реальный код вместо TODO:**
+   - `import Adapty`, `import AdaptyUI`.
+   - `activate()` — читает ключ из `Bundle.main.object(forInfoDictionaryKey:)`, активирует `Adapty.activate(with: AdaptyConfiguration.builder...)`, активирует `AdaptyUI.activate()`, получает `Adapty.getProfile()`, выставляет `profileId` и `isActivated = true`. Если ключа нет или активация упала — остаёмся в anon mode (без crash'а).
+   - `restorePurchases()` — `Adapty.restorePurchases()` + `refreshEntitlement()`. Возвращает `.restored` / `.nothingToRestore` / `.failed(Error)`.
+
+4. **`AdaptyPaywallView` — реальная обёртка над `AdaptyPaywallController`:**
+   - SwiftUI `View` с двумя состояниями: загрузка (`ProgressView`) и `PaywallControllerWrapper` (`UIViewControllerRepresentable`). Если `Adapty.getPaywall(...)` или `AdaptyUI.getPaywallConfiguration(...)` упали (placement не сконфигурирован, нет сети) — fallback-плашка «Сейчас покупка недоступна. Попробуй позже» с кнопкой «Закрыть».
+   - `Coordinator: AdaptyPaywallControllerDelegate` обрабатывает: `.close` → `onClose`, `didFinishPurchase` → если `purchaseResult.success` → `onPurchase`, `didFinishRestoreWith profile` → `onPurchase` (затем рефреш на сервере подтвердит). Ошибки рендеринга → `onClose`.
+
+5. **`xcodebuild build` → `** BUILD SUCCEEDED **`** (только pre-existing Swift 6 warning'и в `APIClient.shared` / `PodcastsRepository.shared` — не related).
+6. **Установка + запуск в booted-симулятор `iPhone 17`** — без crash'ей. SDK не активируется (ключ пустой), `profileId == nil`, бэк видит anon viewer, поведение для существующих юзеров без изменений.
+
+## Файлы
+
+| Файл | Что |
+|---|---|
+| [`scripts/add_adapty_spm.rb`](../../scripts/add_adapty_spm.rb) | new: ruby-скрипт для добавления SPM-зависимости и build settings (идемпотентный) |
+| [`LiboLibo.xcodeproj/project.pbxproj`](../../LiboLibo.xcodeproj/project.pbxproj) | modified: `XCRemoteSwiftPackageReference` для AdaptySDK-iOS, `package_product_dependencies` (Adapty + AdaptyUI), build settings `ADAPTY_PUBLIC_SDK_KEY` + `INFOPLIST_KEY_ADAPTY_PUBLIC_SDK_KEY` |
+| `LiboLibo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved` | new: SPM lockfile (Adapty 3.15.7) |
+| [`LiboLibo/Services/AdaptyService.swift`](../../LiboLibo/Services/AdaptyService.swift) | modified: реальный `Adapty.activate` + `AdaptyUI.activate` + `getProfile`, реальный `restorePurchases` |
+| [`LiboLibo/Features/Subscription/AdaptyPaywallView.swift`](../../LiboLibo/Features/Subscription/AdaptyPaywallView.swift) | modified: `UIViewControllerRepresentable` обёртка над `AdaptyPaywallController`, fallback-плашка для случаев, когда paywall не загрузился |
+
+## Что нужно от пользователя для конца фазы 2.3
+
+1. **Открыть Xcode → Project (LiboLibo) → Build Settings → User-Defined → `ADAPTY_PUBLIC_SDK_KEY`**, вписать ключ из `subs.env`. Закоммитить — **только если это публичный SDK key** (Adapty это разрешает; если по ошибке вписать Secret API key — это критичная ошибка, см. SECURITY.md).
+2. **В Adapty Dashboard:**
+   - Создать paywall и привязать его к **одному** placement'у (или нескольким — `welcome`, `episode-trigger`, `profile-cta`). Сейчас в коде используются три ID, можно сделать один общий и поменять три места в Swift на одно имя.
+   - Добавить продукт (Subscription Group → tier) — Adapty синхронизирует с App Store Connect.
+3. **App Store Connect:**
+   - Subscription Group + tier (например, месячная подписка).
+   - Sandbox-тестер для отладки.
+4. **Sandbox-проверка** (по шагу 9 спеки `step-2.3-premium-adapty-ios.md`):
+   - Купить → бэк отдаёт `audio_url` → плеер играет.
+   - Restore на свежей установке.
+   - Истечение sandbox-подписки → бэк перестаёт отдавать `audio_url` после следующего refresh.
+
+## Открытые вопросы
+
+- Точное имя placement'а в Adapty Dashboard. Сейчас в коде три ID (`welcome`, `episode-trigger`, `profile-cta`). После того как пользователь создаст paywall — обновим эти строки.
+- Текст и оффер на paywall'е — конфигурируется в Adapty Dashboard, не в коде.

--- a/scripts/add_adapty_spm.rb
+++ b/scripts/add_adapty_spm.rb
@@ -1,0 +1,45 @@
+#!/usr/bin/env ruby
+# Adds Adapty + AdaptyUI Swift Package dependencies to the LiboLibo Xcode project.
+# Idempotent — safe to re-run.
+
+require 'xcodeproj'
+
+PROJECT_PATH = File.expand_path('../LiboLibo.xcodeproj', __dir__)
+TARGET_NAME = 'LiboLibo'
+PACKAGE_URL = 'https://github.com/adaptyteam/AdaptySDK-iOS'
+PACKAGE_MIN_VERSION = '3.0.0'
+PRODUCT_NAMES = %w[Adapty AdaptyUI]
+
+project = Xcodeproj::Project.open(PROJECT_PATH)
+target = project.targets.find { |t| t.name == TARGET_NAME }
+abort("Target #{TARGET_NAME} not found") unless target
+
+package_ref = project.root_object.package_references.find { |r| r.repositoryURL == PACKAGE_URL }
+unless package_ref
+  package_ref = project.new(Xcodeproj::Project::Object::XCRemoteSwiftPackageReference)
+  package_ref.repositoryURL = PACKAGE_URL
+  package_ref.requirement = { 'kind' => 'upToNextMajorVersion', 'minimumVersion' => PACKAGE_MIN_VERSION }
+  project.root_object.package_references << package_ref
+end
+
+PRODUCT_NAMES.each do |product_name|
+  if target.package_product_dependencies.any? { |d| d.product_name == product_name }
+    next
+  end
+  dep = project.new(Xcodeproj::Project::Object::XCSwiftPackageProductDependency)
+  dep.package = package_ref
+  dep.product_name = product_name
+  target.package_product_dependencies << dep
+
+  build_file = project.new(Xcodeproj::Project::Object::PBXBuildFile)
+  build_file.product_ref = dep
+  target.frameworks_build_phase.files << build_file
+end
+
+target.build_configurations.each do |config|
+  config.build_settings['INFOPLIST_KEY_ADAPTY_PUBLIC_SDK_KEY'] = '$(ADAPTY_PUBLIC_SDK_KEY)'
+  config.build_settings['ADAPTY_PUBLIC_SDK_KEY'] ||= ''
+end
+
+project.save
+puts "OK: package + products added"


### PR DESCRIPTION
## Summary

- SPM-зависимость `https://github.com/adaptyteam/AdaptySDK-iOS` (Adapty + AdaptyUI, резолвится в 3.15.7), добавлена через ruby xcodeproj gem (`scripts/add_adapty_spm.rb`).
- `AdaptyService.activate()` / `restorePurchases()` — реальные SDK-вызовы вместо TODO-заглушек.
- `AdaptyPaywallView` — `UIViewControllerRepresentable` обёртка над `AdaptyPaywallController` с fallback-плашкой на случай, когда placement не сконфигурирован.
- Build setting `ADAPTY_PUBLIC_SDK_KEY` (User-Defined, пустой) → пробрасывается в Info.plist через `INFOPLIST_KEY_ADAPTY_PUBLIC_SDK_KEY`.

Связано с фазой 2.3 (см. `docs/specs/step-2.3-premium-adapty-ios.md`). Если ключ не задан — приложение работает в anon mode без crash'а (поведение для существующих юзеров не меняется).

## Test plan

- [x] `xcodebuild build` → BUILD SUCCEEDED
- [x] `xcrun simctl install + launch` в booted-симулятор `iPhone 17` без crash'ей
- [ ] Вписать `ADAPTY_PUBLIC_SDK_KEY` в Build Settings, создать paywall + placement в Adapty Dashboard, проверить sandbox-flow (купить → бэк отдаёт `audio_url` → плеер играет; restore; истечение sandbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)