### PR TITLE
Step 3.C: admin moderation UI + public /v1/feed/instagram

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -9,10 +9,14 @@
       "version": "0.1.0",
       "dependencies": {
         "@prisma/client": "^5.22.0",
+        "basic-auth": "^2.0.1",
+        "ejs": "^5.0.2",
         "express": "^4.21.1",
         "fast-xml-parser": "^4.5.0"
       },
       "devDependencies": {
+        "@types/basic-auth": "^1.1.8",
+        "@types/ejs": "^3.1.5",
         "@types/express": "^5.0.0",
         "@types/node": "^22.9.0",
         "prisma": "^5.22.0",
@@ -886,6 +890,16 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/basic-auth": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@types/basic-auth/-/basic-auth-1.1.8.tgz",
+      "integrity": "sha512-dKcUeixGuZn8pBjcUrf1N7x5K6lWuKuwHHitM2IZ4vwZUDWEhhNtwCWiba8jTA9zn0GQQ+fTFkWpKx8pOU/enw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -922,6 +936,13 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ejs": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@types/ejs/-/ejs-3.1.5.tgz",
+      "integrity": "sha512-nv+GSx77ZtXiJzwKdsASqi+YQ5Z7vwHsTP0JY2SiQgjGckkBRKZnk8nIM+7oUZ1VCtuTz0+By4qVR7fqzp/Dfg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1151,6 +1172,24 @@
         "node": ">=12"
       }
     },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/basic-auth/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/body-parser": {
       "version": "1.20.5",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
@@ -1338,6 +1377,18 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
+    },
+    "node_modules/ejs": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-5.0.2.tgz",
+      "integrity": "sha512-IpbUaI/CAW86l3f+T8zN0iggSc0LmMZLcIW5eRVStLVNCoTXkE0YlncbbH50fp8Cl6zHIky0sW2uUbhBqGw0Jw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=0.12.18"
+      }
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -1584,6 +1635,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/api/package.json
+++ b/api/package.json
@@ -21,10 +21,14 @@
   },
   "dependencies": {
     "@prisma/client": "^5.22.0",
+    "basic-auth": "^2.0.1",
+    "ejs": "^5.0.2",
     "express": "^4.21.1",
     "fast-xml-parser": "^4.5.0"
   },
   "devDependencies": {
+    "@types/basic-auth": "^1.1.8",
+    "@types/ejs": "^3.1.5",
     "@types/express": "^5.0.0",
     "@types/node": "^22.9.0",
     "prisma": "^5.22.0",

--- a/api/src/admin/auth.ts
+++ b/api/src/admin/auth.ts
@@ -1,0 +1,31 @@
+// HTTP Basic Auth middleware for /admin. Credentials read from env:
+// ADMIN_USER, ADMIN_PASSWORD. If either is missing, /admin returns 503
+// to make the misconfiguration visible (instead of silently allowing all).
+
+import type { Request, Response, NextFunction } from "express";
+import auth from "basic-auth";
+import { timingSafeEqual } from "node:crypto";
+
+export function basicAuth(req: Request, res: Response, next: NextFunction): void {
+  const expectedUser = process.env.ADMIN_USER;
+  const expectedPass = process.env.ADMIN_PASSWORD;
+  if (!expectedUser || !expectedPass) {
+    res.status(503).type("text/plain").send("admin disabled: ADMIN_USER/ADMIN_PASSWORD not set");
+    return;
+  }
+
+  const credentials = auth(req);
+  if (!credentials || !safeEqual(credentials.name, expectedUser) || !safeEqual(credentials.pass, expectedPass)) {
+    res.set("WWW-Authenticate", 'Basic realm="LiboLibo admin"');
+    res.status(401).type("text/plain").send("authentication required");
+    return;
+  }
+  next();
+}
+
+function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}

--- a/api/src/admin/router.ts
+++ b/api/src/admin/router.ts
@@ -1,0 +1,210 @@
+// Простой server-rendered admin для модерации Instagram-ленты.
+// HTTP Basic Auth, EJS-шаблоны, без SPA. Single editor сценарий.
+
+import { Router } from "express";
+import express from "express";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { prisma } from "../db.js";
+import { basicAuth } from "./auth.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const VIEWS_DIR = path.join(__dirname, "views");
+
+export const adminRouter = Router();
+
+adminRouter.use(basicAuth);
+adminRouter.use(express.urlencoded({ extended: false }));
+
+adminRouter.get("/", (_req, res) => {
+  res.redirect("/admin/posts?status=pending");
+});
+
+adminRouter.get("/posts", async (req, res) => {
+  const status = parseStatus(req.query.status);
+  const posts = await prisma.instagramPost.findMany({
+    where: status ? { status } : undefined,
+    orderBy: { igCreatedAt: "desc" },
+    take: 60,
+    include: {
+      media: {
+        where: { order: 0 },
+        select: { kind: true, filePath: true, thumbnailPath: true },
+        take: 1,
+      },
+    },
+  });
+
+  const counts = await prisma.instagramPost.groupBy({ by: ["status"], _count: true });
+  const countsByStatus: Record<"pending" | "published" | "hidden" | "all", number> = {
+    pending: 0,
+    published: 0,
+    hidden: 0,
+    all: 0,
+  };
+  for (const c of counts) {
+    const k = c.status.toLowerCase() as "pending" | "published" | "hidden";
+    countsByStatus[k] = c._count;
+    countsByStatus.all = countsByStatus.all + c._count;
+  }
+
+  const enriched = posts.map((p) => ({
+    ...p,
+    thumbnailUrl: thumbnailUrlFor(p.media[0]),
+  }));
+
+  res.render(path.join(VIEWS_DIR, "layout.ejs"), {
+    title: `Список постов (${status ?? "all"})`,
+    body: await renderPartial("list.ejs", {
+      posts: enriched,
+      currentStatus: req.query.status ?? "all",
+      counts: countsByStatus,
+    }),
+  });
+});
+
+adminRouter.get("/posts/:id", async (req, res) => {
+  const post = await prisma.instagramPost.findUnique({
+    where: { id: req.params.id },
+    include: { media: { orderBy: { order: "asc" } } },
+  });
+  if (!post) {
+    res.status(404).type("text/plain").send("post not found");
+    return;
+  }
+
+  const [episodes, podcasts] = await Promise.all([
+    prisma.episode.findMany({
+      orderBy: { pubDate: "desc" },
+      take: 200,
+      select: { id: true, title: true },
+    }),
+    prisma.podcast.findMany({
+      orderBy: { name: "asc" },
+      select: { id: true, name: true },
+    }),
+  ]);
+
+  const media = post.media.map((m) => ({
+    kind: m.kind,
+    url: `/media/${m.filePath}`,
+    thumbnailUrl: m.thumbnailPath ? `/media/${m.thumbnailPath}` : null,
+  }));
+
+  res.render(path.join(VIEWS_DIR, "layout.ejs"), {
+    title: `Пост ${post.igMediaId}`,
+    body: await renderPartial("detail.ejs", {
+      post: {
+        ...post,
+        ctaPodcastId: post.ctaPodcastId?.toString() ?? null,
+      },
+      media,
+      episodes,
+      podcasts: podcasts.map((p) => ({ id: p.id.toString(), name: p.name })),
+    }),
+  });
+});
+
+adminRouter.post("/posts/:id", async (req, res) => {
+  const action = String(req.body.action ?? "");
+  const ctaType = String(req.body.cta_type ?? "none");
+
+  const data: {
+    status?: "PENDING" | "PUBLISHED" | "HIDDEN";
+    publishedAt?: Date | null;
+    ctaType?: "EPISODE" | "PODCAST" | "LINK" | null;
+    ctaEpisodeId?: string | null;
+    ctaPodcastId?: bigint | null;
+    ctaUrl?: string | null;
+    ctaLabel?: string | null;
+  } = {};
+
+  switch (ctaType) {
+    case "episode":
+      data.ctaType = "EPISODE";
+      data.ctaEpisodeId = stringOrNull(req.body.cta_episode_id);
+      data.ctaPodcastId = null;
+      data.ctaUrl = null;
+      break;
+    case "podcast":
+      data.ctaType = "PODCAST";
+      data.ctaEpisodeId = null;
+      data.ctaPodcastId = bigintOrNull(req.body.cta_podcast_id);
+      data.ctaUrl = null;
+      break;
+    case "link":
+      data.ctaType = "LINK";
+      data.ctaEpisodeId = null;
+      data.ctaPodcastId = null;
+      data.ctaUrl = stringOrNull(req.body.cta_url);
+      break;
+    case "none":
+    default:
+      data.ctaType = null;
+      data.ctaEpisodeId = null;
+      data.ctaPodcastId = null;
+      data.ctaUrl = null;
+      break;
+  }
+  data.ctaLabel = stringOrNull(req.body.cta_label);
+
+  switch (action) {
+    case "publish":
+      data.status = "PUBLISHED";
+      data.publishedAt = new Date();
+      break;
+    case "hide":
+      data.status = "HIDDEN";
+      data.publishedAt = null;
+      break;
+    case "save_draft":
+      // status/publishedAt не трогаем
+      break;
+    default:
+      res.status(400).type("text/plain").send(`unknown action: ${action}`);
+      return;
+  }
+
+  await prisma.instagramPost.update({
+    where: { id: req.params.id },
+    data,
+  });
+
+  res.redirect(`/admin/posts/${req.params.id}`);
+});
+
+function parseStatus(raw: unknown): "PENDING" | "PUBLISHED" | "HIDDEN" | undefined {
+  if (raw === "pending") return "PENDING";
+  if (raw === "published") return "PUBLISHED";
+  if (raw === "hidden") return "HIDDEN";
+  return undefined;
+}
+
+function thumbnailUrlFor(
+  m?: { kind: "IMAGE" | "VIDEO"; filePath: string; thumbnailPath: string | null },
+): string | null {
+  if (!m) return null;
+  if (m.kind === "IMAGE") return `/media/${m.filePath}`;
+  return m.thumbnailPath ? `/media/${m.thumbnailPath}` : null;
+}
+
+function stringOrNull(v: unknown): string | null {
+  if (typeof v !== "string") return null;
+  const t = v.trim();
+  return t === "" ? null : t;
+}
+
+function bigintOrNull(v: unknown): bigint | null {
+  const s = stringOrNull(v);
+  if (!s) return null;
+  try {
+    return BigInt(s);
+  } catch {
+    return null;
+  }
+}
+
+async function renderPartial(file: string, locals: Record<string, unknown>): Promise<string> {
+  const ejs = await import("ejs");
+  return ejs.default.renderFile(path.join(VIEWS_DIR, file), locals, { async: false });
+}

--- a/api/src/admin/views/detail.ejs
+++ b/api/src/admin/views/detail.ejs
@@ -1,0 +1,66 @@
+<p><a href="/admin/posts">← к списку</a></p>
+
+<div class="detail">
+  <h2>Пост <small style="color:#999;font-weight:400;font-family:monospace"><%= post.igMediaId %></small></h2>
+  <p>
+    <span class="badge <%= post.status %>"><%= post.status %></span>
+    <%= post.type %> ·
+    <%= new Date(post.igCreatedAt).toLocaleString('ru-RU') %> ·
+    <a href="<%= post.igPermalink %>" target="_blank" rel="noopener">открыть в Instagram ↗</a>
+  </p>
+
+  <div style="display:flex;gap:16px;flex-wrap:wrap">
+    <% for (const m of media) { %>
+      <% if (m.kind === 'IMAGE') { %>
+        <img src="<%= m.url %>" style="max-width:240px;max-height:240px;background:#eee" />
+      <% } else { %>
+        <video src="<%= m.url %>" poster="<%= m.thumbnailUrl %>" controls style="max-width:240px;max-height:320px;background:#000"></video>
+      <% } %>
+    <% } %>
+    <% if (media.length === 0) { %>
+      <p style="color:#999">Медиа ещё не скачаны (Phase B downloader пока не отработал).</p>
+    <% } %>
+  </div>
+
+  <% if (post.caption) { %>
+    <p>Caption:</p>
+    <div class="caption"><%= post.caption %></div>
+  <% } %>
+
+  <form method="POST" action="/admin/posts/<%= post.id %>">
+    <fieldset>
+      <legend>CTA</legend>
+      <label><input type="radio" name="cta_type" value="none"     <%= !post.ctaType ? 'checked' : '' %>>          без CTA</label>
+      <label><input type="radio" name="cta_type" value="episode"  <%= post.ctaType === 'EPISODE' ? 'checked' : '' %>>  Эпизод</label>
+      <label><input type="radio" name="cta_type" value="podcast"  <%= post.ctaType === 'PODCAST' ? 'checked' : '' %>>  Подкаст</label>
+      <label><input type="radio" name="cta_type" value="link"     <%= post.ctaType === 'LINK' ? 'checked' : '' %>>     Внешняя ссылка</label>
+
+      <label>Эпизод (id):
+        <select name="cta_episode_id">
+          <option value="">— не выбран —</option>
+          <% for (const e of episodes) { %>
+            <option value="<%= e.id %>" <%= post.ctaEpisodeId === e.id ? 'selected' : '' %>><%= e.title.slice(0, 80) %></option>
+          <% } %>
+        </select>
+      </label>
+
+      <label>Подкаст:
+        <select name="cta_podcast_id">
+          <option value="">— не выбран —</option>
+          <% for (const p of podcasts) { %>
+            <option value="<%= p.id %>" <%= post.ctaPodcastId === p.id ? 'selected' : '' %>><%= p.name %></option>
+          <% } %>
+        </select>
+      </label>
+
+      <label>URL: <input type="url" name="cta_url" value="<%= post.ctaUrl || '' %>" placeholder="https://..."></label>
+      <label>Подпись кнопки: <input type="text" name="cta_label" maxlength="80" value="<%= post.ctaLabel || '' %>" placeholder="Слушать эпизод"></label>
+    </fieldset>
+
+    <div class="actions">
+      <button type="submit" name="action" value="publish" class="publish">Опубликовать</button>
+      <button type="submit" name="action" value="save_draft" class="save">Сохранить черновик</button>
+      <button type="submit" name="action" value="hide" class="hide">Скрыть</button>
+    </div>
+  </form>
+</div>

--- a/api/src/admin/views/layout.ejs
+++ b/api/src/admin/views/layout.ejs
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title><%= title %> — Либо/Либо admin</title>
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 0; background: #f7f7f7; color: #111; }
+  header { background: #111; color: #fff; padding: 12px 24px; display: flex; align-items: center; gap: 16px; }
+  header a { color: #fff; text-decoration: none; }
+  main { padding: 24px; max-width: 1200px; margin: 0 auto; }
+  .filters { display: flex; gap: 8px; margin-bottom: 16px; }
+  .filters a { background: #fff; border: 1px solid #ccc; padding: 6px 12px; border-radius: 6px; text-decoration: none; color: #111; }
+  .filters a.active { background: #c00; color: #fff; border-color: #c00; }
+  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 16px; }
+  .card { background: #fff; border: 1px solid #ddd; border-radius: 8px; overflow: hidden; }
+  .card a { color: #111; text-decoration: none; display: block; }
+  .card .meta { padding: 8px 12px; font-size: 13px; }
+  .card .caption { color: #555; font-size: 12px; height: 36px; overflow: hidden; }
+  .badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-size: 11px; text-transform: uppercase; font-weight: 600; }
+  .badge.PENDING   { background: #fef3c7; color: #92400e; }
+  .badge.PUBLISHED { background: #dcfce7; color: #166534; }
+  .badge.HIDDEN    { background: #fee2e2; color: #991b1b; }
+  .detail { background: #fff; border: 1px solid #ddd; border-radius: 8px; padding: 16px; }
+  .detail h2 { margin-top: 0; }
+  .detail .caption { white-space: pre-wrap; background: #f5f5f5; padding: 12px; border-radius: 6px; max-height: 200px; overflow: auto; }
+  fieldset { border: 1px solid #ccc; border-radius: 6px; padding: 12px; margin: 12px 0; }
+  legend { padding: 0 6px; font-weight: 600; }
+  label { display: block; margin: 6px 0; }
+  input[type="text"], input[type="url"], select { width: 100%; padding: 6px 8px; box-sizing: border-box; }
+  .actions button { padding: 8px 16px; border: 0; border-radius: 6px; cursor: pointer; font-weight: 600; margin-right: 8px; }
+  .actions .publish { background: #16a34a; color: #fff; }
+  .actions .hide    { background: #dc2626; color: #fff; }
+  .actions .save    { background: #6b7280; color: #fff; }
+</style>
+</head>
+<body>
+<header>
+  <strong><a href="/admin/posts">Либо/Либо · Instagram модерация</a></strong>
+</header>
+<main>
+<%- body %>
+</main>
+</body>
+</html>

--- a/api/src/admin/views/list.ejs
+++ b/api/src/admin/views/list.ejs
@@ -1,0 +1,29 @@
+<div class="filters">
+  <% for (const f of ["pending","published","hidden","all"]) { %>
+    <a href="/admin/posts?status=<%= f %>" class="<%= f === currentStatus ? 'active' : '' %>"><%= f %> (<%= counts[f] || 0 %>)</a>
+  <% } %>
+</div>
+
+<% if (posts.length === 0) { %>
+  <p>Нет постов в этом фильтре.</p>
+<% } else { %>
+  <div class="grid">
+    <% for (const p of posts) { %>
+      <div class="card">
+        <a href="/admin/posts/<%= p.id %>">
+          <% if (p.thumbnailUrl) { %>
+            <img src="<%= p.thumbnailUrl %>" alt="" style="width:100%;display:block;aspect-ratio:1/1;object-fit:cover;background:#eee" />
+          <% } else { %>
+            <div style="aspect-ratio:1/1;background:#eee;display:flex;align-items:center;justify-content:center;color:#999"><%= p.type %></div>
+          <% } %>
+          <div class="meta">
+            <span class="badge <%= p.status %>"><%= p.status %></span>
+            <span style="margin-left:8px;color:#666"><%= p.type %></span>
+            <span style="float:right;color:#999"><%= new Date(p.igCreatedAt).toLocaleDateString('ru-RU') %></span>
+            <div class="caption"><%= (p.caption || '').slice(0, 120) %></div>
+          </div>
+        </a>
+      </div>
+    <% } %>
+  </div>
+<% } %>

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -6,6 +6,8 @@ import { episodesRouter } from "./routes/episodes.js";
 import { devicesRouter } from "./routes/devices.js";
 import { meRouter } from "./routes/me.js";
 import { legalRouter } from "./routes/legal.js";
+import { feedInstagramRouter } from "./routes/feed-instagram.js";
+import { adminRouter } from "./admin/router.js";
 
 export function createApp() {
   const app = express();
@@ -30,6 +32,11 @@ export function createApp() {
   app.use("/v1", episodesRouter);
   app.use("/v1", devicesRouter);
   app.use("/v1", meRouter);
+  app.use("/v1", feedInstagramRouter);
+
+  // Web-админка модерации Instagram-ленты (Phase 3.C). HTTP Basic Auth,
+  // server-rendered EJS. Креды в env: ADMIN_USER, ADMIN_PASSWORD.
+  app.use("/admin", adminRouter);
 
   // Legal pages — served at the root, не под /v1, чтобы URL были короткие
   // и удобные для App Store / In-App-листинга.

--- a/api/src/lib/instagram-feed-serialize.ts
+++ b/api/src/lib/instagram-feed-serialize.ts
@@ -1,0 +1,100 @@
+// Чистая функция сериализации InstagramPost (с relations) в DTO для iOS.
+// Никакой работы с БД или сетью — для лёгкого тестирования.
+
+interface MediaRow {
+  order: number;
+  kind: "IMAGE" | "VIDEO";
+  filePath: string;
+  thumbnailPath: string | null;
+  width: number;
+  height: number;
+  durationSec: number | null;
+}
+
+interface EpisodeRow {
+  id: string;
+  title: string;
+  podcastId: bigint;
+}
+
+interface PodcastRow {
+  id: bigint;
+  name: string;
+}
+
+export interface InstagramPostRow {
+  id: string;
+  igPermalink: string;
+  type: "IMAGE" | "CAROUSEL" | "VIDEO";
+  caption: string | null;
+  publishedAt: Date | null;
+  ctaType: "EPISODE" | "PODCAST" | "LINK" | null;
+  ctaEpisodeId: string | null;
+  ctaPodcastId: bigint | null;
+  ctaUrl: string | null;
+  ctaLabel: string | null;
+  media: MediaRow[];
+  ctaEpisode: EpisodeRow | null;
+  ctaPodcast: PodcastRow | null;
+}
+
+export interface SerializeOptions {
+  mediaBaseUrl: string;
+}
+
+export function serializeInstagramPost(post: InstagramPostRow, opts: SerializeOptions) {
+  const media = [...post.media]
+    .sort((a, b) => a.order - b.order)
+    .map((m) => ({
+      kind: m.kind.toLowerCase() as "image" | "video",
+      url: `${opts.mediaBaseUrl}/${m.filePath}`,
+      thumbnailUrl: m.thumbnailPath ? `${opts.mediaBaseUrl}/${m.thumbnailPath}` : null,
+      width: m.width,
+      height: m.height,
+      durationSec: m.durationSec,
+    }));
+
+  return {
+    id: post.id,
+    type: post.type.toLowerCase(),
+    permalink: post.igPermalink,
+    caption: post.caption,
+    publishedAt: post.publishedAt?.toISOString() ?? null,
+    media,
+    cta: serializeCta(post),
+  };
+}
+
+function serializeCta(post: InstagramPostRow) {
+  if (!post.ctaType) return null;
+  switch (post.ctaType) {
+    case "EPISODE":
+      if (!post.ctaEpisode) return null;
+      return {
+        type: "episode" as const,
+        label: post.ctaLabel ?? "Слушать эпизод",
+        episode: {
+          id: post.ctaEpisode.id,
+          title: post.ctaEpisode.title,
+          podcastId: post.ctaEpisode.podcastId.toString(),
+        },
+      };
+    case "PODCAST":
+      if (!post.ctaPodcast) return null;
+      return {
+        type: "podcast" as const,
+        label: post.ctaLabel ?? "Подкаст",
+        podcast: {
+          id: post.ctaPodcast.id.toString(),
+          name: post.ctaPodcast.name,
+        },
+      };
+    case "LINK":
+      if (!post.ctaUrl) return null;
+      return {
+        type: "link" as const,
+        label: post.ctaLabel ?? "Перейти",
+        url: post.ctaUrl,
+      };
+  }
+}

--- a/api/src/routes/feed-instagram.ts
+++ b/api/src/routes/feed-instagram.ts
@@ -1,0 +1,58 @@
+// Public Instagram feed endpoint for the iOS client.
+// Returns only `status=PUBLISHED` posts ordered by publishedAt DESC.
+
+import { Router } from "express";
+import { prisma } from "../db.js";
+import { encodeCursor, decodeCursor, parseLimit } from "../lib/cursor.js";
+import { serializeInstagramPost, type InstagramPostRow } from "../lib/instagram-feed-serialize.js";
+import { asyncHandler } from "../lib/asyncHandler.js";
+
+export const feedInstagramRouter = Router();
+
+const MEDIA_BASE_URL = process.env.MEDIA_BASE_URL ?? "/media";
+
+feedInstagramRouter.get(
+  "/feed/instagram",
+  asyncHandler(async (req, res) => {
+    const limit = parseLimit(req.query.limit, 20, 50);
+    const cursor = decodeCursor(typeof req.query.cursor === "string" ? req.query.cursor : undefined);
+
+    const posts = await prisma.instagramPost.findMany({
+      where: {
+        status: "PUBLISHED",
+        ...(cursor
+          ? {
+              OR: [
+                { publishedAt: { lt: new Date(cursor.ts) } },
+                { publishedAt: new Date(cursor.ts), id: { lt: cursor.id } },
+              ],
+            }
+          : {}),
+      },
+      orderBy: [{ publishedAt: "desc" }, { id: "desc" }],
+      take: limit + 1,
+      include: {
+        media: { orderBy: { order: "asc" } },
+        ctaEpisode: { select: { id: true, title: true, podcastId: true } },
+        ctaPodcast: { select: { id: true, name: true } },
+      },
+    });
+
+    const hasMore = posts.length > limit;
+    const page = hasMore ? posts.slice(0, limit) : posts;
+
+    const items = page.map((p) =>
+      serializeInstagramPost(p as InstagramPostRow, { mediaBaseUrl: MEDIA_BASE_URL }),
+    );
+
+    let nextCursor: string | null = null;
+    if (hasMore) {
+      const last = page[page.length - 1]!;
+      if (last.publishedAt) {
+        nextCursor = encodeCursor({ ts: last.publishedAt.toISOString(), id: last.id });
+      }
+    }
+
+    res.json({ items, nextCursor });
+  }),
+);

--- a/api/test/instagram-feed-serialize.test.ts
+++ b/api/test/instagram-feed-serialize.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { serializeInstagramPost, type InstagramPostRow } from "../src/lib/instagram-feed-serialize.js";
+
+const BASE = { mediaBaseUrl: "https://api.example.com/media" };
+
+const basePost = (over: Partial<InstagramPostRow> = {}): InstagramPostRow => ({
+  id: "11111111-1111-1111-1111-111111111111",
+  igPermalink: "https://www.instagram.com/p/abc/",
+  type: "IMAGE",
+  caption: "hi",
+  publishedAt: new Date("2026-04-25T10:00:00Z"),
+  ctaType: null,
+  ctaEpisodeId: null,
+  ctaPodcastId: null,
+  ctaUrl: null,
+  ctaLabel: null,
+  media: [
+    { order: 0, kind: "IMAGE", filePath: "11111111-1111-1111-1111-111111111111/0.jpg", thumbnailPath: null, width: 1080, height: 1080, durationSec: null },
+  ],
+  ctaEpisode: null,
+  ctaPodcast: null,
+  ...over,
+});
+
+describe("serializeInstagramPost", () => {
+  it("базовый случай: одиночное изображение, без CTA", () => {
+    const out = serializeInstagramPost(basePost(), BASE);
+    expect(out.type).toBe("image");
+    expect(out.permalink).toBe("https://www.instagram.com/p/abc/");
+    expect(out.publishedAt).toBe("2026-04-25T10:00:00.000Z");
+    expect(out.media).toEqual([
+      { kind: "image", url: "https://api.example.com/media/11111111-1111-1111-1111-111111111111/0.jpg", thumbnailUrl: null, width: 1080, height: 1080, durationSec: null },
+    ]);
+    expect(out.cta).toBeNull();
+  });
+
+  it("сортирует media по order", () => {
+    const out = serializeInstagramPost(
+      basePost({
+        type: "CAROUSEL",
+        media: [
+          { order: 2, kind: "IMAGE", filePath: "p/2.jpg", thumbnailPath: null, width: 1, height: 1, durationSec: null },
+          { order: 0, kind: "VIDEO", filePath: "p/0.mp4", thumbnailPath: "p/0.thumb.jpg", width: 2, height: 2, durationSec: 10 },
+          { order: 1, kind: "IMAGE", filePath: "p/1.jpg", thumbnailPath: null, width: 3, height: 3, durationSec: null },
+        ],
+      }),
+      BASE,
+    );
+    expect(out.media.map((m) => m.url)).toEqual([
+      "https://api.example.com/media/p/0.mp4",
+      "https://api.example.com/media/p/1.jpg",
+      "https://api.example.com/media/p/2.jpg",
+    ]);
+    expect(out.media[0]!.thumbnailUrl).toBe("https://api.example.com/media/p/0.thumb.jpg");
+  });
+
+  it("CTA episode → label по умолчанию + nested episode", () => {
+    const out = serializeInstagramPost(
+      basePost({
+        ctaType: "EPISODE",
+        ctaEpisodeId: "ep-1",
+        ctaEpisode: { id: "ep-1", title: "Эпизод про N", podcastId: 12345n },
+      }),
+      BASE,
+    );
+    expect(out.cta).toEqual({
+      type: "episode",
+      label: "Слушать эпизод",
+      episode: { id: "ep-1", title: "Эпизод про N", podcastId: "12345" },
+    });
+  });
+
+  it("CTA link с кастомным label", () => {
+    const out = serializeInstagramPost(
+      basePost({
+        ctaType: "LINK",
+        ctaUrl: "https://libolibo.ru/x",
+        ctaLabel: "Подробнее",
+      }),
+      BASE,
+    );
+    expect(out.cta).toEqual({
+      type: "link",
+      label: "Подробнее",
+      url: "https://libolibo.ru/x",
+    });
+  });
+
+  it("ctaType=PODCAST но ctaPodcast=null → cta=null (защита от рассинхронизации)", () => {
+    const out = serializeInstagramPost(
+      basePost({ ctaType: "PODCAST", ctaPodcastId: 99n, ctaPodcast: null }),
+      BASE,
+    );
+    expect(out.cta).toBeNull();
+  });
+});

--- a/docs/specs/step-03-instagram-feed-plan-phase-c.md
+++ b/docs/specs/step-03-instagram-feed-plan-phase-c.md
@@ -1,0 +1,41 @@
+# Шаг 3 — Фаза C: модерация-админка + публичный API. План
+
+> **Goal:** редактор может зайти в `/admin`, проставить CTA каждому `PENDING` посту и опубликовать. Опубликованные посты отдаются по `GET /v1/feed/instagram?cursor=&limit=` для iOS-клиента.
+
+## Файлы
+
+- Create: `api/src/admin/auth.ts` — HTTP Basic Auth middleware (env: `ADMIN_USER`, `ADMIN_PASSWORD`).
+- Create: `api/src/admin/router.ts` — Express-роутер: `GET /`, `GET /posts`, `GET /posts/:id`, `POST /posts/:id`.
+- Create: `api/src/admin/views/layout.ejs`, `list.ejs`, `detail.ejs` — server-rendered HTML.
+- Create: `api/src/lib/instagram-feed-serialize.ts` — чистая функция превращает `InstagramPost + media + episode + podcast` в DTO для iOS.
+- Create: `api/src/routes/feed-instagram.ts` — `GET /v1/feed/instagram` с курсором по `(publishedAt desc, id)`.
+- Create: `api/test/instagram-feed-serialize.test.ts` — тесты на сериализатор.
+- Modify: `api/src/app.ts` — монтирует `/admin` и `/v1`.
+- Modify: `api/package.json` — `ejs`, `basic-auth` (уже добавлено).
+
+## Архитектура форм
+
+`POST /admin/posts/:id` принимает `application/x-www-form-urlencoded`:
+
+| Поле | Допустимые значения |
+|---|---|
+| `action` | `publish` / `hide` / `save_draft` |
+| `cta_type` | `none` / `episode` / `podcast` / `link` |
+| `cta_episode_id` | string (UUID-ish; для `episode`) |
+| `cta_podcast_id` | string (BigInt; для `podcast`) |
+| `cta_url` | URL (для `link`) |
+| `cta_label` | свободный текст ≤ 80 |
+
+Валидация:
+- При `action=publish` для CTA-варианта обязательны соответствующие поля.
+- При `cta_type=none` пост допускается публиковать без CTA.
+
+## Курсорная пагинация публичного API
+
+Курсор кодирует `(publishedAt-iso, id-uuid)` через `Buffer.from(...).toString('base64url')`. Существующий `lib/cursor.ts` шаблон используется как референс.
+
+## Self-review
+
+- Spec coverage: спека разделы 4.5 (admin) и 4.6 (public API).
+- Все маршруты статусом `PUBLISHED` — фильтр на стороне API.
+- Token/password не в логах: Basic Auth middleware читает `process.env.*`, не печатает.


### PR DESCRIPTION
## Summary

Phase C завершает backend-часть Instagram-ленты:

- **`/admin`** — server-rendered moderation UI с HTTP Basic Auth.
  - Список постов с фильтром по статусу (`pending` / `published` / `hidden` / `all`) и счётчиками.
  - Карточка поста: превью всех медиа, caption, ссылка на оригинал в IG, форма CTA.
  - Радиокнопки `none` / `episode` / `podcast` / `link`, для episode/podcast — выпадашки с поиском по локальной БД, для link — URL + label.
  - Кнопки **Опубликовать** / **Сохранить черновик** / **Скрыть**.
  - Auth через `ADMIN_USER` + `ADMIN_PASSWORD` из env, timing-safe сравнение, 503 если переменные не заданы.

- **`GET /v1/feed/instagram`** — публичный API для iOS-клиента.
  - Курсорная пагинация по `(publishedAt desc, id desc)` — стабильный порядок при равных датах.
  - `?cursor=<base64-cursor>&limit=20` (default 20, max 50).
  - Отдаёт **только `status=PUBLISHED`**.
  - Каждый item содержит `id`, `type`, `permalink`, `caption`, `publishedAt`, массив `media` с `url`/`thumbnailUrl`/размерами/длительностью, и `cta` (`null` либо один из `episode`/`podcast`/`link`).

- **Чистая сериализация** в `src/lib/instagram-feed-serialize.ts` — отделена от роута, легко тестируется. **5 vitest-тестов** покрывают: одиночное изображение без CTA, сортировку media по order, CTA episode с дефолтным label, CTA link с кастомным label, защиту от рассинхрона (`ctaType=PODCAST` при `ctaPodcast=null` → `cta=null`).

Зависимости: `ejs@^5.0.2`, `basic-auth@^2.0.1` (+ типы).

## Зависимости от других PR

- Изоморфно работает после merge **#17 (Phase B)** — карточки в `/admin` и iOS-клиент будут видеть медиа по `/media/...`. До мерджа Phase B превью в админке окажутся `<img src="/media/...">` с 404, но это не блокирует модерацию — caption и кнопки работают. После Phase B превью встанут на места.

## Test plan

- [x] `npm run build` чистый.
- [x] `npm test` — 22 vitest зелёные (5 новых на сериализатор).
- [ ] После merge: в Railway → сервис `LiboLibo` → Variables → добавить `ADMIN_USER` и `ADMIN_PASSWORD`. Дождаться авто-deploy.
- [ ] Открыть `https://<api-domain>/admin/` под этими кредами → видна страница со счётчиками `pending: 30` и сеткой постов.
- [ ] Кликнуть в пост → проставить CTA = episode, выбрать любой эпизод → **Опубликовать**.
- [ ] `curl https://<api-domain>/v1/feed/instagram?limit=5 | jq '.items[0]'` → видим опубликованный пост с `cta.type='episode'`.

## Что НЕ входит в этот PR

- Phase D — iOS экран ленты (отдельный PR в репо клиента).
- Email/SSO для админки (single editor, BasicAuth достаточно).
- Push-уведомления, лайки, шаринг.

🤖 Generated with [Claude Code](https://claude.com/claude-code)