### PR TITLE
ios(subscription): placementId везде «default»

### DIFF
--- a/LiboLibo/App/LiboLiboApp.swift
+++ b/LiboLibo/App/LiboLiboApp.swift
@@ -62,7 +62,7 @@ struct LiboLiboApp: App {
                 }
                 .sheet(isPresented: $showsWelcomePaywall) {
                     AdaptyPaywallView(
-                        placementId: "welcome",
+                        placementId: "default",
                         onPurchase: {
                             showsWelcomePaywall = false
                             Task {

--- a/LiboLibo/Features/Episodes/EpisodeDetailView.swift
+++ b/LiboLibo/Features/Episodes/EpisodeDetailView.swift
@@ -32,7 +32,7 @@ struct EpisodeDetailView: View {
         }
         .sheet(isPresented: $showsPaywall) {
             AdaptyPaywallView(
-                placementId: "episode-trigger",
+                placementId: "default",
                 onPurchase: {
                     showsPaywall = false
                     Task {

--- a/LiboLibo/Features/Profile/ProfileView.swift
+++ b/LiboLibo/Features/Profile/ProfileView.swift
@@ -69,7 +69,7 @@ struct ProfileView: View {
             }
             .sheet(isPresented: $showsPaywall) {
                 AdaptyPaywallView(
-                    placementId: "profile-cta",
+                    placementId: "default",
                     onPurchase: {
                         showsPaywall = false
                         Task {


### PR DESCRIPTION
## Summary

В Adapty Dashboard у нас один paywall «sub», привязанный к одному placement'у «default». Меняем три hardcoded места в коде (welcome / episode-trigger / profile-cta) на единый ID `default`.

## Test plan

- [x] Build succeeded.
- [x] Симулятор запускается без crash'а.
- [ ] С реальным sandbox-тестером: тап «Слушать с премиумом» → загружается paywall «sub» из Adapty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)