### PR TITLE
ios(subscription): Adapty key в Swift-константе

### DIFF
--- a/LiboLibo.xcodeproj/project.pbxproj
+++ b/LiboLibo.xcodeproj/project.pbxproj
@@ -142,7 +142,7 @@
 		6E04F613EEC1CF3DA989E6DF /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ADAPTY_PUBLIC_SDK_KEY = "";
+				ADAPTY_PUBLIC_SDK_KEY = "public_live_rj0kCiWl.y24PVWRN42JhQlvSHcea";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGNING_ALLOWED = NO;
 				CODE_SIGN_STYLE = Automatic;
@@ -289,7 +289,7 @@
 		E3F124E52D6F454A08525EE6 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ADAPTY_PUBLIC_SDK_KEY = "";
+				ADAPTY_PUBLIC_SDK_KEY = "public_live_rj0kCiWl.y24PVWRN42JhQlvSHcea";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGNING_ALLOWED = NO;
 				CODE_SIGN_STYLE = Automatic;

--- a/LiboLibo/Resources/AdaptyConfig.swift
+++ b/LiboLibo/Resources/AdaptyConfig.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Константы Adapty.
+///
+/// `publicSDKKey` — Public SDK Key из Adapty Dashboard. По документации Adapty,
+/// этот ключ предназначен для использования в клиентском коде и считается
+/// публичным (не secret). Хранится в репозитории. Серверный Secret API Key —
+/// в Railway Variables, в репо его быть не должно (см. `SECURITY.md`).
+enum AdaptyConfig {
+    static let publicSDKKey = "public_live_rj0kCiWl.y24PVWRN42JhQlvSHcea"
+}

--- a/LiboLibo/Services/AdaptyService.swift
+++ b/LiboLibo/Services/AdaptyService.swift
@@ -43,10 +43,8 @@ final class AdaptyService {
     /// зовётся отдельно из composition root, чтобы вызывающий мог решить,
     /// нужно ли перезагружать ленту.
     func activate() async {
-        guard let key = Bundle.main.object(forInfoDictionaryKey: "ADAPTY_PUBLIC_SDK_KEY") as? String,
-              !key.isEmpty else {
-            return
-        }
+        let key = AdaptyConfig.publicSDKKey
+        guard !key.isEmpty else { return }
         do {
             let configuration = AdaptyConfiguration
                 .builder(withAPIKey: key)


### PR DESCRIPTION
## Summary

`INFOPLIST_KEY_<custom>` build settings работают только для Apple-известных ключей (CFBundleDisplayName, NSAppTransportSecurity, и т.д.), поэтому `ADAPTY_PUBLIC_SDK_KEY` через `INFOPLIST_KEY_ADAPTY_PUBLIC_SDK_KEY` не попадал в Info.plist приложения, и `Bundle.main.object(forInfoDictionaryKey:)` возвращал `nil`. SDK не активировался → paywall падал с `AdaptyError.notActivated`.

Решение: `LiboLibo/Resources/AdaptyConfig.swift` с константой `publicSDKKey`. Public SDK Key по документации Adapty — публичный identifier (не secret), безопасно для open-source repo.

## Test plan

- [x] Симулятор: лог `[io.adapty:sdk] Adapty activated successfully`.
- [x] Paywall `default` загружается (`getPaywall` больше не падает с `notActivated`).
- [ ] С sandbox-тестером: продукты подтянутся, paywall отрендерится с кнопкой покупки. Пока тестер не залогинен — лог `StoreKitManagerError.noProductIDsFound` (ожидаемо).

🤖 Generated with [Claude Code](https://claude.com/claude-code)