### PR TITLE
Step 3 arch: /internal/refresh-instagram (cron via HTTP)

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -9,6 +9,7 @@ import { legalRouter } from "./routes/legal.js";
 import { mediaRouter } from "./routes/media.js";
 import { feedInstagramRouter } from "./routes/feed-instagram.js";
 import { adminRouter } from "./admin/router.js";
+import { internalRouter } from "./routes/internal.js";
 
 export function createApp() {
   const app = express();
@@ -38,6 +39,11 @@ export function createApp() {
   // Web-админка модерации Instagram-ленты (Phase 3.C). HTTP Basic Auth,
   // server-rendered EJS. Креды в env: ADMIN_USER, ADMIN_PASSWORD.
   app.use("/admin", adminRouter);
+
+  // Internal endpoints (cron-сервис Railway дёргает sync+download через них,
+  // потому что Railway volumes нельзя монтировать в два сервиса; volume на
+  // LiboLibo, фактическую работу тоже делает LiboLibo).
+  app.use("/internal", internalRouter);
 
   // Раздача Instagram-медиа (Phase 3.B). Файлы лежат на Railway volume.
   app.use("/media", mediaRouter);

--- a/api/src/routes/internal.ts
+++ b/api/src/routes/internal.ts
@@ -1,0 +1,39 @@
+// Internal-only endpoints. Защищены через bearer-токен из env
+// (INTERNAL_TOKEN). Используются Cron-сервисами Railway, у которых
+// нет доступа к volume с медиа: они дёргают этот endpoint, а сам
+// LiboLibo-процесс (с примонтированным volume) делает работу.
+
+import { Router } from "express";
+import { syncInstagramPosts } from "../instagram/collector.js";
+import { downloadPendingMedia } from "../instagram/media-downloader.js";
+
+export const internalRouter = Router();
+
+internalRouter.use((req, res, next) => {
+  const expected = process.env.INTERNAL_TOKEN;
+  if (!expected) {
+    res.status(503).type("text/plain").send("internal disabled: INTERNAL_TOKEN not set");
+    return;
+  }
+  const auth = req.header("authorization") ?? "";
+  const presented = auth.startsWith("Bearer ") ? auth.slice("Bearer ".length) : "";
+  if (presented !== expected) {
+    res.status(401).type("text/plain").send("unauthorized");
+    return;
+  }
+  next();
+});
+
+internalRouter.post("/refresh-instagram", async (_req, res) => {
+  // Fire-and-forget: отвечаем сразу, чтобы cron-сервис не висел до окончания
+  // загрузки медиа (она занимает 30-90 секунд для 30 постов).
+  res.status(202).json({ accepted: true });
+
+  try {
+    const sync = await syncInstagramPosts();
+    const download = await downloadPendingMedia();
+    console.log("[refresh-instagram]", JSON.stringify({ sync, download }));
+  } catch (err) {
+    console.error("[refresh-instagram]", err);
+  }
+});


### PR DESCRIPTION
Railway не разрешает монтировать один volume к двум сервисам. Volume на `LiboLibo`. Cron-сервис `cron-refresh-instagram` теперь дёргает `LiboLibo` через HTTP, и refresh+download делается там, где volume.

- `/internal/refresh-instagram` за bearer-токеном (env `INTERNAL_TOKEN`).
- 202 + fire-and-forget (sync+download занимают ~минуту).
- В Cron Service Railway меняется start command на `curl -X POST -H 'Authorization: Bearer $INTERNAL_TOKEN' $INTERNAL_REFRESH_URL`.

Тесты: 27 vitest зелёные. Build чистый.