### PR TITLE
Step 3 arch: refresh-cli falls back to /internal endpoint

### DIFF
--- a/api/src/instagram/refresh-cli.ts
+++ b/api/src/instagram/refresh-cli.ts
@@ -1,14 +1,37 @@
-// Standalone CLI: `npm run refresh:instagram`. Used by Railway Cron Service
-// that runs every 30 minutes (configured separately in Railway UI as a cron
-// service pointing at the same repo, command `npm run refresh:instagram`).
+// Standalone CLI: `npm run refresh:instagram`. Используется Railway Cron Service.
 //
-// Phase A — sync metadata (instagram_posts).
-// Phase B — download media files for posts that don't have them yet
-//          (instagram_media).
+// Двa режима:
+//
+// 1. **Remote** (используется на Railway): если установлены
+//    INTERNAL_REFRESH_URL + INTERNAL_TOKEN — CLI делает POST на этот URL
+//    в LiboLibo-сервис, который сам выполняет sync+download (потому что
+//    Railway volume с медиа смонтирован только в LiboLibo).
+//
+// 2. **Local** (для локальной отладки): если переменных нет — CLI вызывает
+//    syncInstagramPosts + downloadPendingMedia в текущем процессе. Удобно
+//    при запуске на dev-машине, где нет split-сервисной конфигурации.
+
 import { syncInstagramPosts } from "./collector.js";
 import { downloadPendingMedia } from "./media-downloader.js";
 
+const url = process.env.INTERNAL_REFRESH_URL;
+const token = process.env.INTERNAL_TOKEN;
+
 (async () => {
+  if (url && token) {
+    const resp = await fetch(url, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!resp.ok) {
+      throw new Error(`POST ${url} → HTTP ${resp.status}`);
+    }
+    const body = await resp.text();
+    console.log(`triggered ${url} → ${resp.status}: ${body}`);
+    process.exit(0);
+  }
+
+  // Local fallback.
   const sync = await syncInstagramPosts();
   const download = await downloadPendingMedia();
   console.log(JSON.stringify({ sync, download }, null, 2));


### PR DESCRIPTION
Если в env есть INTERNAL_REFRESH_URL + INTERNAL_TOKEN, CLI делает POST туда вместо локального sync+download. Это нужно для Railway-сервиса cron-refresh-instagram, у которого нет volume — фактическую работу делает LiboLibo-сервис.