### PR TITLE
ios(subscription): StoreKit Configuration File для локального теста

### DIFF
--- a/LiboLibo.xcodeproj/project.pbxproj
+++ b/LiboLibo.xcodeproj/project.pbxproj
@@ -18,8 +18,6 @@
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		C49B7815EC13F05F2FEBA9E5 /* LiboLibo */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
 			path = LiboLibo;
 			sourceTree = "<group>";
 		};
@@ -142,7 +140,7 @@
 		6E04F613EEC1CF3DA989E6DF /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ADAPTY_PUBLIC_SDK_KEY = "public_live_rj0kCiWl.y24PVWRN42JhQlvSHcea";
+				ADAPTY_PUBLIC_SDK_KEY = public_live_rj0kCiWl.y24PVWRN42JhQlvSHcea;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGNING_ALLOWED = NO;
 				CODE_SIGN_STYLE = Automatic;
@@ -292,7 +290,7 @@
 		E3F124E52D6F454A08525EE6 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ADAPTY_PUBLIC_SDK_KEY = "public_live_rj0kCiWl.y24PVWRN42JhQlvSHcea";
+				ADAPTY_PUBLIC_SDK_KEY = public_live_rj0kCiWl.y24PVWRN42JhQlvSHcea;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;

--- a/LiboLibo.xcodeproj/xcshareddata/xcschemes/LiboLibo.xcscheme
+++ b/LiboLibo.xcodeproj/xcshareddata/xcschemes/LiboLibo.xcscheme
@@ -50,6 +50,9 @@
             ReferencedContainer = "container:LiboLibo.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <StoreKitConfigurationFileReference
+         identifier = "../../../LiboLibo/LiboLibo.storekit">
+      </StoreKitConfigurationFileReference>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/LiboLibo/LiboLibo.storekit
+++ b/LiboLibo/LiboLibo.storekit
@@ -1,0 +1,65 @@
+{
+  "identifier" : "191F42A9",
+  "nonRenewingSubscriptions" : [],
+  "products" : [],
+  "settings" : {
+    "_applicationInternalID" : "0",
+    "_compatibilityTimeRate" : 1,
+    "_developerTeamID" : "47B25GR8V2",
+    "_disableDialogs" : false,
+    "_failTransactionsEnabled" : false,
+    "_locale" : "ru_RU",
+    "_storefront" : "USA",
+    "_storeKitErrors" : []
+  },
+  "subscriptionGroups" : [
+    {
+      "id" : "32F7B0B1",
+      "localizations" : [
+        {
+          "description" : "Премиум-доступ к Либо-Либо",
+          "displayName" : "Премиум",
+          "locale" : "ru_RU"
+        },
+        {
+          "description" : "Premium access to Libo-Libo",
+          "displayName" : "Premium",
+          "locale" : "en_US"
+        }
+      ],
+      "name" : "Premium",
+      "subscriptions" : [
+        {
+          "adHocOffers" : [],
+          "codeOffers" : [],
+          "displayPrice" : "0.99",
+          "familyShareable" : false,
+          "groupNumber" : 1,
+          "internalID" : "620A2506",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "Бонусные и эксклюзивные выпуски «Либо-Либо».",
+              "displayName" : "Премиум (месяц)",
+              "locale" : "ru_RU"
+            },
+            {
+              "description" : "Bonus and exclusive episodes of Libo-Libo.",
+              "displayName" : "Premium (Monthly)",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "monthly_0_99",
+          "recurringSubscriptionPeriod" : "P1M",
+          "referenceName" : "Monthly Premium",
+          "subscriptionGroupID" : "32F7B0B1",
+          "type" : "RecurringSubscription"
+        }
+      ]
+    }
+  ],
+  "version" : {
+    "major" : 4,
+    "minor" : 0
+  }
+}


### PR DESCRIPTION
## Summary

`LiboLibo/LiboLibo.storekit` описывает локальный продукт `monthly_0_99` (RecurringSubscription, P1M, $0.99). Привязан к Run-action в `LiboLibo.xcscheme`.

При запуске через **Xcode → Cmd+R** StoreKit подменяется на этот файл — sandbox-логин не нужен, продукты появляются мгновенно. Adapty SDK видит paywall, тянет продукт через `Product.products(for:)`, рендерит paywall с кнопкой Buy.

## Ограничения

- Запуск через `xcrun simctl launch` НЕ применяет StoreKit Configuration — только Xcode Run.
- Покупка локальная: до Adapty Server и нашего `POST /v1/me/entitlement/refresh` не доходит. То есть `is_premium=true` на бэке не выставится, `audio_url` останется `null`. Для end-to-end проверки бэк-флоу нужен sandbox-аккаунт.

## Test plan

- [x] Build succeeded.
- [ ] Открыть Xcode → Cmd+R → тапнуть «Слушать с премиумом» → должен появиться paywall с кнопкой `Premium (Monthly) — $0.99`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)