### PR TITLE
rollback: unmount Instagram routes from API

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -7,10 +7,12 @@ import { devicesRouter } from "./routes/devices.js";
 import { meRouter } from "./routes/me.js";
 import { commentsRouter } from "./routes/comments.js";
 import { legalRouter } from "./routes/legal.js";
-import { mediaRouter } from "./routes/media.js";
-import { feedInstagramRouter } from "./routes/feed-instagram.js";
-import { adminRouter } from "./admin/router.js";
-import { internalRouter } from "./routes/internal.js";
+
+// NB: Instagram-фича (Phase 3.A/B/C) временно отключена на проде, чтобы
+// не блокировать остальную работу. Файлы остаются в репо:
+//   src/admin/, src/instagram/, src/routes/{feed-instagram,internal,media}.ts
+// Чтобы вернуть в строй — вернуть импорты и app.use ниже плюс пересоздать
+// Railway-сервис cron-refresh-instagram. Спека: docs/specs/step-03-instagram-feed.md.
 
 export function createApp() {
   const app = express();
@@ -36,19 +38,6 @@ export function createApp() {
   app.use("/v1", devicesRouter);
   app.use("/v1", meRouter);
   app.use("/v1", commentsRouter);
-  app.use("/v1", feedInstagramRouter);
-
-  // Web-админка модерации Instagram-ленты (Phase 3.C). HTTP Basic Auth,
-  // server-rendered EJS. Креды в env: ADMIN_USER, ADMIN_PASSWORD.
-  app.use("/admin", adminRouter);
-
-  // Internal endpoints (cron-сервис Railway дёргает sync+download через них,
-  // потому что Railway volumes нельзя монтировать в два сервиса; volume на
-  // LiboLibo, фактическую работу тоже делает LiboLibo).
-  app.use("/internal", internalRouter);
-
-  // Раздача Instagram-медиа (Phase 3.B). Файлы лежат на Railway volume.
-  app.use("/media", mediaRouter);
 
   // Legal pages — served at the root, не под /v1, чтобы URL были короткие
   // и удобные для App Store / In-App-листинга.


### PR DESCRIPTION
Откатываем Phase 3.A/B/C **только в плане runtime** — код, тесты, спеки, план остаются в репо (см. `src/admin/`, `src/instagram/`, `docs/specs/step-03-instagram-feed*`).

Причина: Phase B/C ещё не закончены до production-ready состояния (Railway volume не разделяется между сервисами, healthcheck timing). Фича блокирует основную работу. Отвязываем от `createApp`, чтобы LiboLibo-сервис стал стабильным.

Что делаю помимо PR:
- удаляю Railway-сервис `cron-refresh-instagram` через CLI;
- снимаю env-переменные `META_*`, `INTERNAL_TOKEN`, `ADMIN_*` с `LiboLibo`;
- volume `libolibo-volume` пока оставляю пустым (не мешает).

Чтобы вернуть фичу — восстановить импорты + `app.use` в `src/app.ts` и пересоздать cron-сервис из спеки.