### PR TITLE
Open podcast detail from player

### DIFF
--- a/LiboLibo/App/RootView.swift
+++ b/LiboLibo/App/RootView.swift
@@ -8,12 +8,31 @@ struct RootView: View {
     @Environment(PlayerService.self) private var player
     @State private var showFullPlayer = false
     @State private var selectedTab: SelectedTab = .feed
+    @State private var pendingPodcastToOpenId: Int?
+    @State private var currentOpenedPodcastId: Int?
+    @State private var podcastsViewIdentity = UUID()
 
     var body: some View {
         tabContainer
             .sheet(isPresented: $showFullPlayer) {
                 PlayerView()
                     .presentationDragIndicator(.visible)
+            }
+            .onReceive(NotificationCenter.default.publisher(for: Notification.Name("OpenPodcastDetailFromPlayer"))) { note in
+                if let id = note.userInfo?["podcastId"] as? Int {
+                    if selectedTab == .podcasts, currentOpenedPodcastId == id {
+                        // Already on the same podcast detail — just dismiss the player.
+                        showFullPlayer = false
+                        return
+                    }
+                    selectedTab = .podcasts
+                    showFullPlayer = false
+                    podcastsViewIdentity = UUID()
+                    pendingPodcastToOpenId = nil
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                        pendingPodcastToOpenId = id
+                    }
+                }
             }
     }
 
@@ -56,7 +75,8 @@ struct RootView: View {
             FeedView()
         }
         Tab("Подкасты", systemImage: "rectangle.grid.2x2", value: SelectedTab.podcasts) {
-            PodcastsView()
+            PodcastsView(openPodcastId: $pendingPodcastToOpenId, currentOpenedPodcastId: $currentOpenedPodcastId)
+                .id(podcastsViewIdentity)
         }
         Tab("Моё", systemImage: "person.crop.circle", value: SelectedTab.profile) {
             ProfileView(onOpenPodcasts: { selectedTab = .podcasts })

--- a/LiboLibo/Features/Player/PlayerView.swift
+++ b/LiboLibo/Features/Player/PlayerView.swift
@@ -91,12 +91,18 @@ private struct Titles: View {
 
     var body: some View {
         VStack(spacing: 4) {
-            Text(episode.podcastName)
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-                .fixedSize(horizontal: false, vertical: true)
 
+            Button {
+                NotificationCenter.default.post(name: Notification.Name("OpenPodcastDetailFromPlayer"), object: nil, userInfo: ["podcastId": episode.podcastId])
+            } label: {
+                Text(episode.podcastName)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .buttonStyle(.plain)
+            
             Text(episode.title)
                 .font(.headline)
                 .foregroundStyle(.primary)

--- a/LiboLibo/Features/Podcasts/PodcastsView.swift
+++ b/LiboLibo/Features/Podcasts/PodcastsView.swift
@@ -4,6 +4,8 @@ struct PodcastsView: View {
     @Environment(PodcastsRepository.self) private var repository
     @Environment(PodcastColorService.self) private var colors
 
+    @Binding var openPodcastId: Int?
+    @Binding var currentOpenedPodcastId: Int?
     @State private var path = NavigationPath()
 
     var body: some View {
@@ -12,21 +14,21 @@ struct PodcastsView: View {
                 if !active.isEmpty {
                     Section("Выходят сейчас") {
                         ForEach(active) { podcast in
-                            PodcastListItem(podcast: podcast) { path.append(podcast) }
+                            PodcastListItem(podcast: podcast) { open(podcast, replacingStack: false) }
                         }
                     }
                 }
                 if !recent.isEmpty {
                     Section("Недавно выходили") {
                         ForEach(recent) { podcast in
-                            PodcastListItem(podcast: podcast) { path.append(podcast) }
+                            PodcastListItem(podcast: podcast) { open(podcast, replacingStack: false) }
                         }
                     }
                 }
                 if !dormant.isEmpty {
                     Section("Давно не выходят") {
                         ForEach(dormant) { podcast in
-                            PodcastListItem(podcast: podcast) { path.append(podcast) }
+                            PodcastListItem(podcast: podcast) { open(podcast, replacingStack: false) }
                         }
                     }
                 }
@@ -35,6 +37,26 @@ struct PodcastsView: View {
             .navigationTitle("Подкасты")
             .navigationDestination(for: Podcast.self) { podcast in
                 PodcastDetailView(podcast: podcast, path: $path)
+            }
+            .task(id: openPodcastId) {
+                if let id = openPodcastId,
+                   let podcast = repository.podcasts.first(where: { $0.id == id }) {
+                    try? await Task.sleep(nanoseconds: 180_000_000) // ~0.18s for smooth push after tab switch
+                    open(podcast, replacingStack: true)
+                    openPodcastId = nil
+                }
+            }
+            .onChange(of: repository.podcasts.count) { _, _ in
+                if let id = openPodcastId,
+                   let podcast = repository.podcasts.first(where: { $0.id == id }) {
+                    open(podcast, replacingStack: true)
+                    openPodcastId = nil
+                }
+            }
+            .onChange(of: path.count) { _, newCount in
+                if newCount == 0 {
+                    currentOpenedPodcastId = nil
+                }
             }
         }
         .task(id: repository.podcasts.count) {
@@ -80,6 +102,19 @@ struct PodcastsView: View {
                 return d < twelveAgo
             }
             .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
+
+    private func open(_ podcast: Podcast, replacingStack: Bool) {
+        if replacingStack {
+            var newPath = NavigationPath()
+            newPath.append(podcast)
+            path = newPath
+            currentOpenedPodcastId = podcast.id
+            return
+        }
+
+        path.append(podcast)
+        currentOpenedPodcastId = podcast.id
     }
 }
 
@@ -175,6 +210,6 @@ private struct SubscribeButton: View {
 }
 
 #Preview {
-    PodcastsView()
+    PodcastsView(openPodcastId: .constant(nil), currentOpenedPodcastId: .constant(nil))
         .environment(PodcastsRepository())
 }


### PR DESCRIPTION
```
Что сделано

Добавлена навигация из full-player в карточку подкаста:

- название подкаста в `PlayerView` стало кликабельным;
- по тапу приложение закрывает full-player, переключается на вкладку «Подкасты» и открывает нужный `PodcastDetailView`;
- если нужная карточка уже открыта, приложение просто закрывает full-player без повторного push;
- `PodcastsView` получил программное открытие подкаста по `podcastId`.

Проверка

- `xcodebuild -project LiboLibo.xcodeproj -scheme LiboLibo -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17' -configuration Debug build`
- `** BUILD SUCCEEDED **`
- установка в booted simulator прошла успешно
- запуск приложения в simulator прошёл успешно
```